### PR TITLE
Allow users to require() source directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "throttle-debounce-fn",
   "version": "1.0.1",
   "description": "jQuery-based plugin that allows you to throttle and debounce your functions",
-  "main": "Gruntfile.js",
+  "main": "src/throttle-debounce-fn.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/migueldemoura/throttle-debounce-fn.git"


### PR DESCRIPTION
It seems odd that package.json is defining the Gruntfile as the default module export, I think it should be the source file?

This way users can do this:

```js
$ = require('jquery');
debounce = require('throttle-debounce-fn');
```

Rather than this:

```js
$ = require('jquery');
debounce = require('throttle-debounce-fn/src/throttle-debounce-fn.js');
```